### PR TITLE
fix: 首次 setup 时自动 wrangler login，避免强制要 CLOUDFLARE_API_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm run deploy
 
 **Prerequisites:**
 - [NVIDIA API Key](https://build.nvidia.com) - Required during `npm run setup`
-- Cloudflare account - Will prompt to login during first `npm run deploy`
+- Cloudflare account - `npm run setup` will prompt to login on first run (or set `CLOUDFLARE_API_TOKEN` env var for non-interactive use)
 
 After deployment, you'll get a Worker URL: `https://nvidia-anthropic-proxy.xxx.workers.dev`
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -23,7 +23,7 @@ npm run deploy
 
 **准备工作：**
 - [NVIDIA API Key](https://build.nvidia.com) - 在 `npm run setup` 时输入
-- Cloudflare 账户 - 首次 `npm run deploy` 时会提示登录
+- Cloudflare 账户 - 首次 `npm run setup` 时会提示登录（或设置 `CLOUDFLARE_API_TOKEN` 环境变量以非交互方式使用）
 
 部署成功后会显示 Worker 地址：`https://nvidia-anthropic-proxy.xxx.workers.dev`
 

--- a/setup.sh
+++ b/setup.sh
@@ -15,6 +15,14 @@ npm install
 
 echo
 
+# 确保已登录 Cloudflare：pipe 给 wrangler 会让 stdin 变成非交互式，
+# 此时若未登录就会强制要 CLOUDFLARE_API_TOKEN，所以先在这里登录
+if ! npx wrangler whoami >/dev/null 2>&1; then
+    echo "Cloudflare not logged in. Opening browser to login..."
+    npx wrangler login
+    echo
+fi
+
 # 配置 NVIDIA_API_KEY
 echo "Enter your NVIDIA API Key:"
 read -s NVIDIA_KEY


### PR DESCRIPTION
## Summary
- `setup.sh` 把 NVIDIA_API_KEY / AUTH_TOKEN 通过 pipe 喂给 `npx wrangler secret put`，stdin 变成非交互式，wrangler 在未登录时会强制要求 `CLOUDFLARE_API_TOKEN`（即 issue #1 报的错）
- 在写 secret 之前先 `npx wrangler whoami` 检测登录状态，未登录则跑 `npx wrangler login` 打开浏览器交互登录
- README / README_CN 同步说明：首次跑 `npm run setup` 会触发登录，或可设置 `CLOUDFLARE_API_TOKEN` 走非交互流程

Closes #1

## Test plan
- [ ] 在未登录 Cloudflare 的环境跑 `npm run setup`，确认浏览器登录后能成功写入 secret
- [ ] 在已登录环境跑 `npm run setup`，确认跳过登录步骤
- [ ] 在 CI / 已设置 `CLOUDFLARE_API_TOKEN` 的环境跑 `npm run setup`，确认仍然非交互可用

🤖 Generated with [Claude Code](https://claude.com/claude-code)